### PR TITLE
Don't use statsd server name as the event source host

### DIFF
--- a/src/main/java/com/github/arnabk/statsd/BlockingStatsDEventClient.java
+++ b/src/main/java/com/github/arnabk/statsd/BlockingStatsDEventClient.java
@@ -249,9 +249,6 @@ public class BlockingStatsDEventClient  {
     	if (dateHappened > 0) {
     		sb.append(String.format("|d:%d", dateHappened));
     	}
-    	if (hostname != null) {
-    		sb.append(String.format("|h:%s", hostname));
-    	}
     	if (aggregationKey != null) {
     		sb.append(String.format("|k:%s", aggregationKey));
     	}

--- a/src/test/java/com/github/arnabk/statsd/BlockingStatsDEventClientTest.java
+++ b/src/test/java/com/github/arnabk/statsd/BlockingStatsDEventClientTest.java
@@ -34,7 +34,7 @@ public class BlockingStatsDEventClientTest {
         client.event("title", "message");
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|h:localhost"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message"));
     }
 
     @Test public void
@@ -44,7 +44,7 @@ public class BlockingStatsDEventClientTest {
         client.event("title", "message", 1);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|d:1|h:localhost"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|d:1"));
     }
 
     @Test public void
@@ -54,7 +54,7 @@ public class BlockingStatsDEventClientTest {
         client.event("title", "message", AlertType.warning);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|h:localhost|t:warning"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|t:warning"));
     }
 
     @Test public void
@@ -64,7 +64,7 @@ public class BlockingStatsDEventClientTest {
         client.event("title", "message", Priority.normal);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|h:localhost|p:normal"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|p:normal"));
     }
 
     @Test public void
@@ -74,7 +74,7 @@ public class BlockingStatsDEventClientTest {
         client.event("title", "message", new String[] {"tag1:tag1", "tag2:tag2"});
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|h:localhost|#tag2:tag2,tag1:tag1"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|#tag2:tag2,tag1:tag1"));
     }
 
     @Test public void
@@ -84,7 +84,7 @@ public class BlockingStatsDEventClientTest {
         client.event("title", "message", 1, "testAggregationKey", Priority.normal, "sourceTypeName", AlertType.error, new String[] {"tag1:tag1", "tag2:tag2"});
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|d:1|h:localhost|k:testAggregationKey|p:normal|s:sourceTypeName|t:error|#tag2:tag2,tag1:tag1"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|d:1|k:testAggregationKey|p:normal|s:sourceTypeName|t:error|#tag2:tag2,tag1:tag1"));
     }
 
 }

--- a/src/test/java/com/github/arnabk/statsd/NonBlockingStatsDEventClientTest.java
+++ b/src/test/java/com/github/arnabk/statsd/NonBlockingStatsDEventClientTest.java
@@ -34,7 +34,7 @@ public class NonBlockingStatsDEventClientTest {
         client.event("title", "message");
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|h:localhost"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message"));
     }
 
     @Test public void
@@ -44,7 +44,7 @@ public class NonBlockingStatsDEventClientTest {
         client.event("title", "message", 1);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|d:1|h:localhost"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|d:1"));
     }
 
     @Test public void
@@ -54,7 +54,7 @@ public class NonBlockingStatsDEventClientTest {
         client.event("title", "message", AlertType.warning);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|h:localhost|t:warning"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|t:warning"));
     }
 
     @Test public void
@@ -64,7 +64,7 @@ public class NonBlockingStatsDEventClientTest {
         client.event("title", "message", Priority.normal);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|h:localhost|p:normal"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|p:normal"));
     }
 
     @Test public void
@@ -74,7 +74,7 @@ public class NonBlockingStatsDEventClientTest {
         client.event("title", "message", new String[] {"tag1:tag1", "tag2:tag2"});
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|h:localhost|#tag2:tag2,tag1:tag1"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|#tag2:tag2,tag1:tag1"));
     }
 
     @Test public void
@@ -84,7 +84,7 @@ public class NonBlockingStatsDEventClientTest {
         client.event("title", "message", 1, "testAggregationKey", Priority.normal, "sourceTypeName", AlertType.error, new String[] {"tag1:tag1", "tag2:tag2"});
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|d:1|h:localhost|k:testAggregationKey|p:normal|s:sourceTypeName|t:error|#tag2:tag2,tag1:tag1"));
+        assertThat(server.messagesReceived(), contains("_e{5,7}:title|message|d:1|k:testAggregationKey|p:normal|s:sourceTypeName|t:error|#tag2:tag2,tag1:tag1"));
     }
 
 }


### PR DESCRIPTION
In the client class the variable hostname gets initialized by the constructur, it will hold the hostname of the (dog-)statsd server to connect to. When sending a message this same variable will be used to populate the hostname field in datadog.

In a datadog setting the dogstatsd is almost always sitting on localhost, so any clients of this library that connect to localhost, will have their hostname set to localhost. Furthermore, setting the hostname to localhost suppresses the datadog agents mechanisms to add more tags to the event that has been generated. This lead to missing tags in the most common usage scenarios.

This change removes the usage of the "h:XX" field in the datagrams sent to datadog. This ensures default agent tags get applied to the event.